### PR TITLE
Fix/deprecations

### DIFF
--- a/src/Driver/Exception.php
+++ b/src/Driver/Exception.php
@@ -15,11 +15,35 @@ declare(strict_types=1);
 
 namespace Drift\DBAL\Driver;
 
-use Doctrine\DBAL\Driver\AbstractException;
+use Throwable;
 
 /**
  * Class Exception.
  */
-class Exception extends AbstractException
+class Exception extends \Exception implements \Doctrine\DBAL\Driver\Exception
 {
+    /**
+     * The SQLSTATE of the driver.
+     *
+     * @var string|null
+     */
+    private $sqlState;
+
+    /**
+     * @param string         $message  The driver error message.
+     * @param string|null    $sqlState The SQLSTATE the driver is in at the time the error occurred, if any.
+     * @param int            $code     The driver specific error code if any.
+     * @param Throwable|null $previous The previous throwable used for the exception chaining.
+     */
+    public function __construct($message, $sqlState = null, $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->sqlState = $sqlState;
+    }
+
+    public function getSQLState()
+    {
+        return $this->sqlState;
+    }
 }

--- a/src/Driver/Mysql/EmptyDoctrineMysqlDriver.php
+++ b/src/Driver/Mysql/EmptyDoctrineMysqlDriver.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Drift\DBAL\Driver\Mysql;
 
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Exception;
 
 /**
@@ -26,7 +27,7 @@ final class EmptyDoctrineMysqlDriver extends AbstractMySQLDriver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = []): DriverConnection
     {
         throw new Exception('Do not use this method.');
     }

--- a/src/Driver/PostgreSQL/EmptyDoctrinePostgreSQLDriver.php
+++ b/src/Driver/PostgreSQL/EmptyDoctrinePostgreSQLDriver.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Drift\DBAL\Driver\PostgreSQL;
 
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Exception;
 
 /**
@@ -26,7 +27,7 @@ final class EmptyDoctrinePostgreSQLDriver extends AbstractPostgreSQLDriver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = []): DriverConnection
     {
         throw new Exception('Do not use this method.');
     }

--- a/src/Driver/SQLite/EmptyDoctrineSQLiteDriver.php
+++ b/src/Driver/SQLite/EmptyDoctrineSQLiteDriver.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Drift\DBAL\Driver\SQLite;
 
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Exception;
 
 /**
@@ -26,7 +27,7 @@ final class EmptyDoctrineSQLiteDriver extends AbstractSQLiteDriver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = []): DriverConnection
     {
         throw new Exception('Do not use this method.');
     }

--- a/src/Mock/MockedDBALConnection.php
+++ b/src/Mock/MockedDBALConnection.php
@@ -52,8 +52,10 @@ class MockedDBALConnection extends Connection
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
-    public function quote($input, $type = ParameterType::STRING)
+    public function quote($input, $type = ParameterType::STRING)/*: mixed // <--- from php 8*/
     {
         throw new Exception('Mocked method. Unable to be used');
     }
@@ -70,8 +72,10 @@ class MockedDBALConnection extends Connection
 
     /**
      * {@inheritdoc}
+     *
+     * @return string|int|false A string representation of the last inserted ID.
      */
-    public function lastInsertId($name = null)
+    public function lastInsertId($name = null)/*: string|int|false // <--- from php 8 */
     {
         throw new Exception('Mocked method. Unable to be used');
     }
@@ -79,7 +83,7 @@ class MockedDBALConnection extends Connection
     /**
      * {@inheritdoc}
      */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         throw new Exception('Mocked method. Unable to be used');
     }
@@ -87,7 +91,7 @@ class MockedDBALConnection extends Connection
     /**
      * {@inheritdoc}
      */
-    public function commit()
+    public function commit(): bool
     {
         throw new Exception('Mocked method. Unable to be used');
     }
@@ -95,7 +99,7 @@ class MockedDBALConnection extends Connection
     /**
      * {@inheritdoc}
      */
-    public function rollBack()
+    public function rollBack(): bool
     {
         throw new Exception('Mocked method. Unable to be used');
     }

--- a/src/Mock/MockedDriver.php
+++ b/src/Mock/MockedDriver.php
@@ -17,6 +17,7 @@ namespace Drift\DBAL\Mock;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -30,7 +31,7 @@ class MockedDriver implements Driver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = []): DriverConnection
     {
         throw new Exception('Mocked method. Unable to be used');
     }
@@ -38,7 +39,7 @@ class MockedDriver implements Driver
     /**
      * {@inheritdoc}
      */
-    public function getDatabasePlatform()
+    public function getDatabasePlatform(): AbstractPlatform
     {
         throw new Exception('Mocked method. Unable to be used');
     }
@@ -49,7 +50,7 @@ class MockedDriver implements Driver
      *
      * @return AbstractSchemaManager
      */
-    public function getSchemaManager(Connection $conn, AbstractPlatform $platform)
+    public function getSchemaManager(Connection $conn, AbstractPlatform $platform): AbstractSchemaManager
     {
         throw new Exception('Mocked method. Unable to be used');
     }


### PR DESCRIPTION
fixes deprecations notices below. And one "internal" notice.

```
Method "Doctrine\DBAL\Driver::connect()" might add "DriverConnection" as a native return type declaration in the future. Do the same in implementation "Drift\DBAL\Driver\Mysql\EmptyDoctrineMysqlDriver" now to avoid errors or add an explicit @return annotation to suppress this message.
\vendor\symfony\error-handler\DebugClassLoader.php@325

Method "Doctrine\DBAL\Connection::quote()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Drift\DBAL\Mock\MockedDBALConnection" now to avoid errors or add an explicit @return annotation to suppress this message.
\vendor\symfony\error-handler\DebugClassLoader.php@325

Method "Doctrine\DBAL\Connection::lastInsertId()" might add "string|int|false" as a native return type declaration in the future. Do the same in child class "Drift\DBAL\Mock\MockedDBALConnection" now to avoid errors or add an explicit @return annotation to suppress this message.
\vendor\symfony\error-handler\DebugClassLoader.php@325

Method "Doctrine\DBAL\Connection::beginTransaction()" might add "bool" as a native return type declaration in the future. Do the same in child class "Drift\DBAL\Mock\MockedDBALConnection" now to avoid errors or add an explicit @return annotation to suppress this message.
\vendor\symfony\error-handler\DebugClassLoader.php@325

Method "Doctrine\DBAL\Connection::commit()" might add "bool" as a native return type declaration in the future. Do the same in child class "Drift\DBAL\Mock\MockedDBALConnection" now to avoid errors or add an explicit @return annotation to suppress this message.
\vendor\symfony\error-handler\DebugClassLoader.php@325

Method "Doctrine\DBAL\Connection::rollBack()" might add "bool" as a native return type declaration in the future. Do the same in child class "Drift\DBAL\Mock\MockedDBALConnection" now to avoid errors or add an explicit @return annotation to suppress this message.
\vendor\symfony\error-handler\DebugClassLoader.php@325

Method "Doctrine\DBAL\Driver::connect()" might add "DriverConnection" as a native return type declaration in the future. Do the same in implementation "Drift\DBAL\Mock\MockedDriver" now to avoid errors or add an explicit @return annotation to suppress this message.
\vendor\symfony\error-handler\DebugClassLoader.php@325

Method "Doctrine\DBAL\Driver::getDatabasePlatform()" might add "AbstractPlatform" as a native return type declaration in the future. Do the same in implementation "Drift\DBAL\Mock\MockedDriver" now to avoid errors or add an explicit @return annotation to suppress this message.
\vendor\symfony\error-handler\DebugClassLoader.php@325

The "Doctrine\DBAL\Driver\AbstractException" class is considered internal. It may change without further notice. You should not use it from "Drift\DBAL\Driver\Exception".
\vendor\symfony\error-handler\DebugClassLoader.php@325
```